### PR TITLE
Add support for Django 4+

### DIFF
--- a/djangojs/test_urls.py
+++ b/djangojs/test_urls.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from django import forms
-from django.conf.urls import patterns, url, include
-from django.urls import reverse
+from django.urls import reverse, re_path, include
 from django.views.generic import TemplateView
 from django.views.generic.edit import BaseFormView
 
@@ -43,52 +42,52 @@ class QUnitTestView(QUnitView):
     js_files = 'js/test/qunit/qunit-*.js'
 
 
-fake_patterns = patterns('',
-    url(r'^fake$', TestFormView.as_view(), name='fake'),
+fake_patterns = (
+    re_path(r'^fake$', TestFormView.as_view(), name='fake'),
 )
 
-nested_patterns = patterns('',
-    url(r'^nested/', include(fake_patterns, namespace="nested", app_name="appnested")),
+nested_patterns = (
+    re_path(r'^nested/', include(fake_patterns, namespace="nested", app_name="appnested")),
 )
 
-other_fake_patterns = patterns('',
-    url(r'^fake$', TestFormView.as_view(), name='fake'),
+other_fake_patterns = (
+    re_path(r'^fake$', TestFormView.as_view(), name='fake'),
 )
 
-test_patterns = patterns('',
-    url(r'^form$', TestFormView.as_view(), name='test_form'),
-    url(r'^unamed$', 'djangojs.test_urls.unnamed'),
-    url(r'^unnamed-class$', TestFormView.as_view()),
-    url(r'^arg/(\d+)$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='test_arg'),
-    url(r'^arg/(\d+)/(\w)$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='test_arg_multi'),
-    url(r'^named/(?P<test>\w+)$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='test_named'),
-    url(r'^named/(?P<str>\w+)/(?P<num>\d+)$',
-        TemplateView.as_view(template_name='djangojs/test/test1.html'),
-        name='test_named_multi'),
-    url(r'^named/(?P<test>\d+(?:,\d+)*)$',
-        TemplateView.as_view(template_name='djangojs/test/test1.html'),
-        name='test_named_nested'),
-    url(r'^optionnals?$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name="opt"),
-    url(r'^optionnal/?$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name="opt-trailing-slash"),
-    url(r'^many?/optionnals?$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name="opt_multi"),
-    url(r'^optionnal/(?:capturing)?group$',
-        TemplateView.as_view(template_name='djangojs/test/test1.html'),
-        name="opt_grp"),
-    url(r'^first/$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='twice'),
-    url(r'^last/$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='twice'),
-    url(r'^namespace1/', include(fake_patterns, namespace="ns1", app_name="app1")),
-    url(r'^namespace2/', include(nested_patterns, namespace="ns2", app_name="app2")),
-    url(r'^namespace3/', include(fake_patterns, namespace="ns3")),
-    url(r'^test\.json$', TestFormView.as_view(), name='escaped'),
+test_patterns = (
+    re_path(r'^form$', TestFormView.as_view(), name='test_form'),
+    re_path(r'^unamed$', 'djangojs.test_urls.unnamed'),
+    re_path(r'^unnamed-class$', TestFormView.as_view()),
+    re_path(r'^arg/(\d+)$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='test_arg'),
+    re_path(r'^arg/(\d+)/(\w)$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='test_arg_multi'),
+    re_path(r'^named/(?P<test>\w+)$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='test_named'),
+    re_path(r'^named/(?P<str>\w+)/(?P<num>\d+)$',
+            TemplateView.as_view(template_name='djangojs/test/test1.html'),
+            name='test_named_multi'),
+    re_path(r'^named/(?P<test>\d+(?:,\d+)*)$',
+            TemplateView.as_view(template_name='djangojs/test/test1.html'),
+            name='test_named_nested'),
+    re_path(r'^optionnals?$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name="opt"),
+    re_path(r'^optionnal/?$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name="opt-trailing-slash"),
+    re_path(r'^many?/optionnals?$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name="opt_multi"),
+    re_path(r'^optionnal/(?:capturing)?group$',
+            TemplateView.as_view(template_name='djangojs/test/test1.html'),
+            name="opt_grp"),
+    re_path(r'^first/$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='twice'),
+    re_path(r'^last/$', TemplateView.as_view(template_name='djangojs/test/test1.html'), name='twice'),
+    re_path(r'^namespace1/', include(fake_patterns, namespace="ns1", app_name="app1")),
+    re_path(r'^namespace2/', include(nested_patterns, namespace="ns2", app_name="app2")),
+    re_path(r'^namespace3/', include(fake_patterns, namespace="ns3")),
+    re_path(r'^test\.json$', TestFormView.as_view(), name='escaped'),
 )
 
-urlpatterns = patterns('',
-    url(r'^$', DjangoJsTestView.as_view(), name='djangojs_tests'),
+urlpatterns = (
+    re_path(r'^$', DjangoJsTestView.as_view(), name='djangojs_tests'),
 
-    url(r'^djangojs/', include('djangojs.urls')),
+    re_path(r'^djangojs/', include('djangojs.urls')),
 
-    url(r'^jasmine/$', JasmineTestView.as_view(), name='djangojs_jasmine_tests'),
-    url(r'^qunit/$', QUnitTestView.as_view(), name='djangojs_qunit_tests'),
+    re_path(r'^jasmine/$', JasmineTestView.as_view(), name='djangojs_jasmine_tests'),
+    re_path(r'^qunit/$', QUnitTestView.as_view(), name='djangojs_qunit_tests'),
 
-    url(r'^test/', include(test_patterns)),
+    re_path(r'^test/', include(test_patterns)),
 )

--- a/djangojs/tests/test_context.py
+++ b/djangojs/tests/test_context.py
@@ -130,8 +130,8 @@ class ContextTestMixin(object):
         for code, name in settings.LANGUAGES:
             self.assertEqual(languages[code], name)
 
-    @override_settings(LANGUAGE_CODE='en-us', LANGUAGES=[('fr', translation.ugettext_lazy('French'))])
-    def test_ugettext_lazy(self):
+    @override_settings(LANGUAGE_CODE='en-us', LANGUAGES=[('fr', translation.gettext_lazy('French'))])
+    def test_gettext_lazy(self):
         '''Serialization should not fail on lazy translations'''
         result = self.process_request(headers={'HTTP_ACCEPT_LANGUAGE': 'fr'})
         self.assertIn('LANGUAGES', result)

--- a/djangojs/tests/test_javascript.py
+++ b/djangojs/tests/test_javascript.py
@@ -1,6 +1,6 @@
 from django.conf import global_settings
 from django.test.utils import override_settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from djangojs.runners import JsTestCase, JsTemplateTestCase, JasmineSuite, QUnitSuite
 

--- a/djangojs/urls.py
+++ b/djangojs/urls.py
@@ -3,7 +3,7 @@ import sys
 
 from os.path import join, isdir
 
-from django.conf.urls import patterns, url
+from django.urls import re_path
 
 from djangojs.conf import settings
 from djangojs.views import UrlsJsonView, ContextJsonView, JsInitView
@@ -29,9 +29,9 @@ def js_info_dict():
     return js_info_dict
 
 
-urlpatterns = patterns('',
-    url(r'^init\.js$', JsInitView.as_view(), name='django_js_init'),
-    url(r'^urls$', UrlsJsonView.as_view(), name='django_js_urls'),
-    url(r'^context$', ContextJsonView.as_view(), name='django_js_context'),
-    url(r'^translation$', 'django.views.i18n.javascript_catalog', js_info_dict(), name='js_catalog'),
+urlpatterns = (
+    re_path(r'^init\.js$', JsInitView.as_view(), name='django_js_init'),
+    re_path(r'^urls$', UrlsJsonView.as_view(), name='django_js_urls'),
+    re_path(r'^context$', ContextJsonView.as_view(), name='django_js_context'),
+    re_path(r'^translation$', 'django.views.i18n.javascript_catalog', js_info_dict(), name='js_catalog'),
 )

--- a/djangojs/utils.py
+++ b/djangojs/utils.py
@@ -11,7 +11,7 @@ import sys
 from django.contrib.staticfiles import finders
 from django.contrib.staticfiles.utils import matches_patterns
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import Promise
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ class LazyJsonEncoder(DjangoJSONEncoder):
     '''
     def default(self, obj):
         if isinstance(obj, Promise):
-            return force_text(obj)
+            return force_str(obj)
         return super(LazyJsonEncoder, self).default(obj)
 
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,1 +1,1 @@
-django>=1.4
+django>=2.0


### PR DESCRIPTION
- Updates usages of the following deprecated Django functions:
  * django.utils.encoding.force_text.
  * django.utils.translation.ugettext_lazy
- Replaces the following import
  * from django.conf.urls import include, url with
  * from django.urls import include, re_path
- Removes the usage of from django.conf.urls import patterns as it no longer exists since Django 1.11.